### PR TITLE
Add bulk translation support for mods folder

### DIFF
--- a/app/processing.py
+++ b/app/processing.py
@@ -293,25 +293,32 @@ def load_json(path: Path) -> Dict[str, str]:
         return json.load(f)
 
 
-MOD_LANG_RE = re.compile(r"^assets/([^/]+)/lang/en_us\.json$")
+MOD_LANG_RE = re.compile(r"^assets/([^/]+)/lang/([a-z0-9_]+)\.json$", re.IGNORECASE)
 
 
-def read_en_us_from_jar(jar_path: Path) -> Dict[str, Dict[str, str]]:
-    """JAR 内の assets/<modid>/lang/en_us.json を全て読み取る。"""
-    out: Dict[str, Dict[str, str]] = {}
+def read_lang_files_from_jar(jar_path: Path) -> Tuple[Dict[str, Dict[str, str]], Dict[str, Dict[str, str]]]:
+    """JAR 内の assets/<modid>/lang/{lang}.json を読み取る（en_us と ja_jp）。"""
+    en_maps: Dict[str, Dict[str, str]] = {}
+    ja_maps: Dict[str, Dict[str, str]] = {}
     with zipfile.ZipFile(jar_path, "r") as zf:
         for name in zf.namelist():
             m = MOD_LANG_RE.match(name)
             if not m:
                 continue
             modid = m.group(1)
+            lang = m.group(2).lower()
             try:
                 with zf.open(name) as f:
                     data = json.loads(f.read().decode("utf-8"))
-                out[modid] = {str(k): str(v) for k, v in data.items()}
             except Exception:
                 pass
-    return out
+            else:
+                normalized = {str(k): str(v) for k, v in data.items()}
+                if lang == "en_us":
+                    en_maps[modid] = normalized
+                elif lang == "ja_jp":
+                    ja_maps[modid] = normalized
+    return en_maps, ja_maps
 
 
 def choose_primary_modid(mod_maps: Dict[str, Dict[str, str]]) -> Tuple[str, Dict[str, str]]:
@@ -354,7 +361,8 @@ def extract_localizations(
     log: Optional[LogFn] = None,
     progress: Optional[ProgressFn] = None,
 ) -> ExtractionResult:
-    mod_maps = read_en_us_from_jar(jar_path)
+    en_maps, ja_maps = read_lang_files_from_jar(jar_path)
+    mod_maps = en_maps
     if not mod_maps:
         raise ValueError("JAR 内に assets/<modid>/lang/en_us.json が見つかりませんでした。")
     if len(mod_maps) > 1 and log:
@@ -375,6 +383,12 @@ def extract_localizations(
             log(f"[OK] 抽出: {modid} -> {en_path}")
         if primary_modid == modid:
             primary_en_path = en_path
+        ja_map = ja_maps.get(modid)
+        if ja_map:
+            ja_path = mod_dir / "ja_jp.json"
+            write_json(ja_path, ja_map)
+            if log:
+                log(f"[INFO] 既存の ja_jp.json を取り込みました: {ja_path} ({len(ja_map)} keys)")
         done += 1
         if progress:
             progress(done / total, f"{done}/{total}")

--- a/app/ui.py
+++ b/app/ui.py
@@ -619,6 +619,16 @@ $notifier.Show($toast)
             display = jar_path if jar_path else "(未指定)"
             self._append_log(f"[ERROR] Mod JAR が見つかりません: {display}")
             return
+        jar_targets: list[Path]
+        if jar_path.is_dir():
+            jar_targets = sorted(
+                [p for p in jar_path.iterdir() if p.is_file() and p.suffix.lower() == ".jar"]
+            )
+            if not jar_targets:
+                self._append_log(f"[ERROR] 指定フォルダに Mod JAR が見つかりません: {jar_path}")
+                return
+        else:
+            jar_targets = [jar_path]
         if out_dir is None:
             self._append_log("[ERROR] 出力フォルダを指定してください。")
             return
@@ -646,18 +656,31 @@ $notifier.Show($toast)
                 temp_dir_obj = tempfile.TemporaryDirectory(prefix="mc_localizer_")
                 temp_dir_path = Path(temp_dir_obj.name)
                 self._append_log(f"[INFO] 一時作業フォルダ: {temp_dir_path}")
-                self._append_log(f"[RUN] 抽出: {jar_path}")
-                result: ExtractionResult = extract_localizations(
-                    jar_path,
-                    temp_dir_path,
-                    log=self._append_log,
-                    progress=self._set_progress,
-                )
                 targets: list[tuple[str, Path]] = []
-                for modid in result.mod_maps.keys():
-                    en_path = temp_dir_path / modid / "en_us.json"
-                    if en_path.exists():
-                        targets.append((modid, en_path))
+                jar_count = len(jar_targets)
+                for idx, jar_file in enumerate(jar_targets, start=1):
+                    if jar_count > 1:
+                        self._append_log(f"[RUN] 抽出 {idx}/{jar_count}: {jar_file}")
+                    else:
+                        self._append_log(f"[RUN] 抽出: {jar_file}")
+                    jar_out_dir = temp_dir_path
+                    if jar_count > 1:
+                        jar_out_dir = temp_dir_path / jar_file.stem
+                        jar_out_dir.mkdir(parents=True, exist_ok=True)
+                    try:
+                        result: ExtractionResult = extract_localizations(
+                            jar_file,
+                            jar_out_dir,
+                            log=self._append_log,
+                            progress=self._set_progress,
+                        )
+                    except Exception as ex:
+                        self._append_log(f"[WARN] 抽出に失敗したためスキップします ({jar_file}): {repr(ex)}")
+                        continue
+                    for modid in result.mod_maps.keys():
+                        en_path = jar_out_dir / modid / "en_us.json"
+                        if en_path.exists():
+                            targets.append((modid, en_path))
                 if targets:
                     self._append_log("[RUN] 抽出が完了したため、翻訳を開始します。")
                     summary = self._translate_targets(targets, jar_path, temp_dir_path, out_dir)


### PR DESCRIPTION
## Summary
- allow selecting a mods directory and translating all contained mod JARs in one run, skipping failures per file
- preserve existing ja_jp.json entries extracted from JARs so that only missing keys are sent for translation

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68f0952c9ccc83279f8873de057929fd