### PR TITLE
Add streaming feedback for translation

### DIFF
--- a/app/processing.py
+++ b/app/processing.py
@@ -160,6 +160,7 @@ def translate_batch(
     model: str,
     system_instructions: str,
     _retry_depth: int = 0,
+    stream_handler: Optional[Callable[[str, Optional[str]], None]] = None,
 ) -> Tuple[Dict[str, str], UsageStats]:
     payload = json.dumps(items, ensure_ascii=False, indent=2)
     user_text = USER_TEMPLATE.replace("<<PAYLOAD>>", payload)
@@ -239,7 +240,32 @@ def translate_batch(
         if with_response_format:
             args["response_format"] = response_format_schema
         try:
-            resp = client.responses.create(**args)  # type: ignore[arg-type]
+            if stream_handler:
+                chunks: List[str] = []
+                stream_error: Optional[str] = None
+                with client.responses.stream(**args) as stream:  # type: ignore[arg-type]
+                    for event in stream:
+                        etype = getattr(event, "type", "")
+                        if etype == "response.output_text.delta":
+                            delta = getattr(event, "delta", "") or ""
+                            if delta:
+                                chunks.append(delta)
+                                stream_handler("delta", delta)
+                        elif etype == "response.error":
+                            err = getattr(event, "error", None)
+                            message = ""
+                            if err is not None:
+                                message = getattr(err, "message", "") or str(err)
+                            stream_error = message or "OpenAI streaming error"
+                            if message:
+                                stream_handler("error", message)
+                    resp = stream.get_final_response()
+                if stream_error:
+                    raise RuntimeError(stream_error)
+                out = "".join(chunks)
+            else:
+                resp = client.responses.create(**args)  # type: ignore[arg-type]
+                out = ""
         except TypeError:
             if with_response_format:
                 return _call_responses(
@@ -248,7 +274,8 @@ def translate_batch(
                 )
             raise
         usage = _usage_from_response(resp)
-        out = _extract_text(resp)
+        if not out:
+            out = _extract_text(resp)
         last_raw = out or ""
         return _parse_any(out), usage
 
@@ -462,6 +489,7 @@ def translate_localizations(
     progress: Optional[ProgressFn] = None,
     should_stop: Optional[StopFn] = None,
     sleep_interval: float = 0.4,
+    stream_events: Optional[Callable[[str, Optional[str]], None]] = None,
 ) -> TranslationResult:
     if should_stop is None:
         should_stop = lambda: False
@@ -496,7 +524,8 @@ def translate_localizations(
     usage_batches: List[UsageStats] = []
     if progress and total:
         progress(0.0, f"0/{total}")
-    for batch in batches:
+    total_batches = len(batches)
+    for batch_index, batch in enumerate(batches, start=1):
         if should_stop():
             stopped = True
             if log:
@@ -507,7 +536,22 @@ def translate_localizations(
         for k, protected in batch:
             kv[k] = (protected, {})
             payload.append({"key": k, "value": protected})
-        out_map, batch_usage = translate_batch(client, payload, model=model, system_instructions=system_instructions)
+        if stream_events:
+            stream_events("start", f"バッチ {batch_index}/{total_batches}")
+        def _handle_stream(event: str, payload_text: Optional[str]) -> None:
+            if stream_events:
+                stream_events(event, payload_text)
+        try:
+            out_map, batch_usage = translate_batch(
+                client,
+                payload,
+                model=model,
+                system_instructions=system_instructions,
+                stream_handler=_handle_stream if stream_events else None,
+            )
+        finally:
+            if stream_events:
+                stream_events("end", None)
         usage_total.add(batch_usage)
         usage_batches.append(batch_usage)
         for k, (protected2, m) in kv.items():

--- a/app/ui.py
+++ b/app/ui.py
@@ -48,6 +48,7 @@ class LocalizeApp:
     def __init__(self, page: ft.Page):
         self.page = page
         self.stop_event = threading.Event()
+        self._streaming_active = False
         # 保存キー
         self.K_API = "openai_api_key"
         self.K_MODEL = "openai_model"
@@ -494,6 +495,31 @@ class LocalizeApp:
         self.log.value = (self.log.value + ("\n" if self.log.value else "")) + msg
         self.log.update()
 
+    def _stream_start(self, label: str):
+        if self._streaming_active:
+            self._stream_end()
+        if label:
+            self._append_log(f"[LLM] {label}")
+        else:
+            self._append_log("[LLM] 応答を受信中...")
+        self.log.value += " "
+        self.log.update()
+        self._streaming_active = True
+
+    def _stream_chunk(self, chunk: str):
+        if not chunk:
+            return
+        self.log.value += chunk
+        self.log.update()
+
+    def _stream_end(self):
+        if not self._streaming_active:
+            return
+        if not self.log.value.endswith("\n"):
+            self.log.value += "\n"
+            self.log.update()
+        self._streaming_active = False
+
     def _set_progress(self, ratio: float, text: str = ""):
         self.progress.value = max(0.0, min(1.0, ratio))
         self.progress.update()
@@ -762,6 +788,20 @@ $notifier.Show($toast)
                     label = f"{_modid}: {label}" if label else _modid
                     self._set_progress(ratio, label)
 
+                def _stream_event(event: str, payload: str | None, *, _modid: str = modid):
+                    if event == "start":
+                        label = payload or "応答を受信中..."
+                        self._stream_start(f"{_modid} {label}")
+                    elif event == "delta":
+                        if payload:
+                            self._stream_chunk(payload)
+                    elif event == "error":
+                        if payload:
+                            self._stream_chunk(f"(エラー: {payload})")
+                        self._stream_end()
+                    elif event == "end":
+                        self._stream_end()
+
                 try:
                     result = translate_localizations(
                         api_key=api_key,
@@ -771,6 +811,7 @@ $notifier.Show($toast)
                         log=self._append_log,
                         progress=_progress_wrapper,
                         should_stop=self.stop_event.is_set,
+                        stream_events=_stream_event,
                     )
                     total_entries += result.total
                     translated_entries += result.created


### PR DESCRIPTION
## Summary
- add streaming support to the OpenAI translation pipeline so batches can stream incremental text
- surface streaming updates in the UI log for better feedback while translations run

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68f0a455e5f08327b62cd01cbb181914