### PR TITLE
Remove OpenAI streaming usage and improve logging readability

### DIFF
--- a/app/processing.py
+++ b/app/processing.py
@@ -160,7 +160,6 @@ def translate_batch(
     model: str,
     system_instructions: str,
     _retry_depth: int = 0,
-    stream_handler: Optional[Callable[[str, Optional[str]], None]] = None,
 ) -> Tuple[Dict[str, str], UsageStats]:
     payload = json.dumps(items, ensure_ascii=False, indent=2)
     user_text = USER_TEMPLATE.replace("<<PAYLOAD>>", payload)
@@ -241,32 +240,7 @@ def translate_batch(
         if with_response_format:
             args["response_format"] = response_format_schema
         try:
-            if stream_handler:
-                chunks: List[str] = []
-                stream_error: Optional[str] = None
-                with client.responses.stream(**args) as stream:  # type: ignore[arg-type]
-                    for event in stream:
-                        etype = getattr(event, "type", "")
-                        if etype == "response.output_text.delta":
-                            delta = getattr(event, "delta", "") or ""
-                            if delta:
-                                chunks.append(delta)
-                                stream_handler("delta", delta)
-                        elif etype == "response.error":
-                            err = getattr(event, "error", None)
-                            message = ""
-                            if err is not None:
-                                message = getattr(err, "message", "") or str(err)
-                            stream_error = message or "OpenAI streaming error"
-                            if message:
-                                stream_handler("error", message)
-                    resp = stream.get_final_response()
-                if stream_error:
-                    raise RuntimeError(stream_error)
-                out = "".join(chunks)
-            else:
-                resp = client.responses.create(**args)  # type: ignore[arg-type]
-                out = ""
+            resp = client.responses.create(**args)  # type: ignore[arg-type]
         except TypeError:
             if with_response_format:
                 return _call_responses(
@@ -275,8 +249,7 @@ def translate_batch(
                 )
             raise
         usage = _usage_from_response(resp)
-        if not out:
-            out = _extract_text(resp)
+        out = _extract_text(resp)
         last_raw = out or ""
         return _parse_list(out), usage
 
@@ -497,7 +470,6 @@ def translate_localizations(
     progress: Optional[ProgressFn] = None,
     should_stop: Optional[StopFn] = None,
     sleep_interval: float = 0.4,
-    stream_events: Optional[Callable[[str, Optional[str]], None]] = None,
     resume_path: Optional[Path] = None,
 ) -> TranslationResult:
     if should_stop is None:
@@ -587,22 +559,12 @@ def translate_localizations(
         for k, protected in batch:
             kv[k] = (protected, {})
             payload.append({"key": k, "value": protected})
-        if stream_events:
-            stream_events("start", f"バッチ {batch_index}/{total_batches}")
-        def _handle_stream(event: str, payload_text: Optional[str]) -> None:
-            if stream_events:
-                stream_events(event, payload_text)
-        try:
-            out_map, batch_usage = translate_batch(
-                client,
-                payload,
-                model=model,
-                system_instructions=system_instructions,
-                stream_handler=_handle_stream if stream_events else None,
-            )
-        finally:
-            if stream_events:
-                stream_events("end", None)
+        out_map, batch_usage = translate_batch(
+            client,
+            payload,
+            model=model,
+            system_instructions=system_instructions,
+        )
         usage_total.add(batch_usage)
         usage_batches.append(batch_usage)
         for k, (protected2, m) in kv.items():

--- a/app/ui.py
+++ b/app/ui.py
@@ -48,7 +48,8 @@ class LocalizeApp:
     def __init__(self, page: ft.Page):
         self.page = page
         self.stop_event = threading.Event()
-        self._streaming_active = False
+        self._log_lines: list[str] = []
+        self._max_log_lines = 500
         # 保存キー
         self.K_API = "openai_api_key"
         self.K_MODEL = "openai_model"
@@ -492,33 +493,21 @@ class LocalizeApp:
     # Log & Progress
     # ------------------------------
     def _append_log(self, msg: str):
-        self.log.value = (self.log.value + ("\n" if self.log.value else "")) + msg
+        timestamp = datetime.now().strftime("%H:%M:%S")
+        raw_lines = msg.splitlines() or [msg]
+        indent = " " * (len(timestamp) + 3)
+        for idx, raw in enumerate(raw_lines):
+            content = raw.strip() if raw.strip() else raw
+            line = f"[{timestamp}] {content}" if idx == 0 else f"{indent}{content}"
+            self._log_lines.append(line)
+        if len(self._log_lines) > self._max_log_lines:
+            self._log_lines = self._log_lines[-self._max_log_lines :]
+        self.log.value = "\n".join(self._log_lines)
+        try:
+            self.log.scroll_to(offset=1.0, duration=0)
+        except Exception:
+            pass
         self.log.update()
-
-    def _stream_start(self, label: str):
-        if self._streaming_active:
-            self._stream_end()
-        if label:
-            self._append_log(f"[LLM] {label}")
-        else:
-            self._append_log("[LLM] 応答を受信中...")
-        self.log.value += " "
-        self.log.update()
-        self._streaming_active = True
-
-    def _stream_chunk(self, chunk: str):
-        if not chunk:
-            return
-        self.log.value += chunk
-        self.log.update()
-
-    def _stream_end(self):
-        if not self._streaming_active:
-            return
-        if not self.log.value.endswith("\n"):
-            self.log.value += "\n"
-            self.log.update()
-        self._streaming_active = False
 
     def _set_progress(self, ratio: float, text: str = ""):
         self.progress.value = max(0.0, min(1.0, ratio))
@@ -800,20 +789,6 @@ $notifier.Show($toast)
                     label = f"{_modid}: {label}" if label else _modid
                     self._set_progress(ratio, label)
 
-                def _stream_event(event: str, payload: str | None, *, _modid: str = modid):
-                    if event == "start":
-                        label = payload or "応答を受信中..."
-                        self._stream_start(f"{_modid} {label}")
-                    elif event == "delta":
-                        if payload:
-                            self._stream_chunk(payload)
-                    elif event == "error":
-                        if payload:
-                            self._stream_chunk(f"(エラー: {payload})")
-                        self._stream_end()
-                    elif event == "end":
-                        self._stream_end()
-
                 pack_lang_path = existing_pack_translations.get(modid)
                 resume_path = resume_root / modid / "ja_jp.json"
                 resume_exists = resume_path.exists()
@@ -843,7 +818,6 @@ $notifier.Show($toast)
                         log=self._append_log,
                         progress=_progress_wrapper,
                         should_stop=self.stop_event.is_set,
-                        stream_events=_stream_event,
                         resume_path=resume_path,
                     )
                     total_entries += result.total


### PR DESCRIPTION
## Summary
- remove usage of OpenAI responses streaming APIs from the translation pipeline
- simplify batch translation calls to always use standard response creation
- rework the UI logger to format entries with timestamps and limit retained lines for readability

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68f0f8264e50832793250ae8c3281962