### PR TITLE
Improve log readability and progress display

### DIFF
--- a/app/processing.py
+++ b/app/processing.py
@@ -59,6 +59,23 @@ ProgressFn = Callable[[float, str], None]
 StopFn = Callable[[], bool]
 
 
+def format_block_progress(current: int, total: int, *, width: int = 20) -> str:
+    total = max(total, 0)
+    if total == 0:
+        cells = max(1, width)
+        bar = "█" * cells
+        return f"[{bar}] 100%（0完了・残り0）"
+
+    current_clamped = max(0, min(current, total))
+    ratio = current_clamped / total
+    cells = max(1, width)
+    filled = min(cells, int(round(ratio * cells)))
+    bar = "█" * filled + "░" * (cells - filled)
+    percent = int(round(ratio * 100))
+    remaining = max(0, total - current_clamped)
+    return f"[{bar}] {percent:3d}%（{current_clamped}完了・残り{remaining}）"
+
+
 @dataclass
 class UsageStats:
     prompt_tokens: int = 0
@@ -410,7 +427,7 @@ def extract_localizations(
         mod_maps = read_en_us_from_jar(jar)
         if not mod_maps:
             if log:
-                log(f"[WARN] en_us.json が見つからないためスキップしました: {jar}")
+                log(f"[WARN] en_us.json が見つからないためスキップしました: {jar.name}")
             continue
         per_jar_maps.append((jar, mod_maps))
         total_mods += len(mod_maps)
@@ -421,8 +438,14 @@ def extract_localizations(
     done = 0
     for jar, mod_maps in per_jar_maps:
         if len(mod_maps) > 1 and log:
-            mods = ", ".join(f"{m}({len(d)} keys)" for m, d in mod_maps.items())
-            log(f"[WARN] 複数 namespace を含む Mod を検出しました ({jar}): {mods}。全て処理します。")
+            items = "\n".join(
+                f"- {m}（キー数: {len(d)}）" for m, d in mod_maps.items()
+            )
+            log(
+                "[WARN] 複数 namespace を含む Mod を検出しました。全て処理します。\n"
+                f"- 対象 JAR: {jar.name}\n"
+                f"{items}"
+            )
         ja_maps = read_lang_from_jar(jar, "ja_jp")
         for modid, en_map in mod_maps.items():
             mod_dir = out_dir / modid
@@ -435,20 +458,23 @@ def extract_localizations(
             aggregated_maps[modid] = en_map
             mod_sources[modid] = jar
             if log:
-                note = " (既存の ja_jp を読み込み)" if existing_ja else ""
-                log(f"[OK] 抽出: {modid} -> {en_path}{note}")
+                note = "（既存の ja_jp を読み込み）" if existing_ja else ""
+                log(f"[OK] 抽出: {modid}{note}")
             if primary_modid is None or (len(en_map) > len(primary_map or {})):
                 primary_modid = modid
                 primary_map = en_map
                 primary_en_path = en_path
             done += 1
             if progress and total_mods:
-                progress(done / total_mods, f"{done}/{total_mods}")
+                progress(
+                    done / total_mods,
+                    format_block_progress(done, total_mods, width=12),
+                )
 
     if log and primary_modid and primary_map is not None:
         log(f"[INFO] 最大キー数の Mod: {primary_modid}（キー数: {len(primary_map)}）")
     if progress and total_mods:
-        progress(1.0, f"{total_mods}/{total_mods}")
+        progress(1.0, format_block_progress(total_mods, total_mods, width=12))
 
     return ExtractionResult(
         primary_modid=primary_modid,
@@ -475,8 +501,8 @@ def translate_localizations(
     if should_stop is None:
         should_stop = lambda: False
     if log:
-        log(f"[RUN] 入力: {in_path}")
-        log(f"[RUN] 出力: {out_path}")
+        log("[RUN] 入力ファイルを読み込みます。")
+        log("[RUN] 出力ファイルを準備します。")
     src: Dict[str, str] = load_json(in_path)
     dst: Dict[str, str] = load_json(out_path)
     resume_data: Dict[str, str] = {}
@@ -506,7 +532,7 @@ def translate_localizations(
     if resume_path and resume_path.exists():
         resume_data = load_json(resume_path)
         if log and resume_data:
-            log(f"[INFO] 中断された翻訳データを読み込みます: {resume_path}")
+            log("[INFO] 中断された翻訳データを読み込みます。")
         if _merge_missing(resume_data) and log:
             log("[INFO] 中断データから未訳を引き継ぎます。")
     todo: List[Tuple[str, str]] = []
@@ -529,7 +555,7 @@ def translate_localizations(
         if log:
             log("[OK] すでに翻訳済みです（差分なし）。")
         if progress:
-            progress(1.0, "完了")
+            progress(1.0, format_block_progress(total, total, width=12))
         if resume_path and resume_path.exists():
             try:
                 resume_path.unlink()
@@ -546,7 +572,7 @@ def translate_localizations(
     usage_total = UsageStats()
     usage_batches: List[UsageStats] = []
     if progress and total:
-        progress(0.0, f"0/{total}")
+        progress(0.0, format_block_progress(0, total, width=12))
     total_batches = len(batches)
     for batch_index, batch in enumerate(batches, start=1):
         if should_stop():
@@ -577,23 +603,28 @@ def translate_localizations(
             created += 1
         if progress:
             ratio = created / max(1, total)
-            progress(ratio, f"{created}/{total}")
+            progress(ratio, format_block_progress(created, total, width=12))
         if log:
-            log(f"[INFO] バッチ完了: {created}/{total}")
+            log(
+                f"[INFO] バッチ完了: {format_block_progress(created, total, width=12)}"
+            )
         if sleep_interval > 0:
             time.sleep(sleep_interval)
     write_json(out_path, dst)
     if log:
-        log(f"[OK] 書き込み完了: {out_path}")
+        log("[OK] ja_jp.json の書き込みが完了しました。")
     if progress:
         final_ratio = created / max(1, total)
-        progress(1.0 if not stopped else final_ratio, f"{created}/{total}")
+        progress(
+            1.0 if not stopped else final_ratio,
+            format_block_progress(created, total, width=12),
+        )
     remaining = sum(1 for k in src if str(dst.get(k, "")).strip() == "")
     if resume_path:
         if remaining > 0 or stopped:
             write_json(resume_path, dst)
             if log:
-                log(f"[INFO] 翻訳の進捗を保存しました: {resume_path}")
+                log("[INFO] 翻訳の進捗を保存しました。")
         else:
             try:
                 if resume_path.exists():

--- a/app/ui.py
+++ b/app/ui.py
@@ -16,7 +16,12 @@ from xml.sax import saxutils
 
 import flet as ft
 
-from processing import ExtractionResult, extract_localizations, translate_localizations
+from processing import (
+    ExtractionResult,
+    extract_localizations,
+    format_block_progress,
+    translate_localizations,
+)
 
 APP_NAME = "MC Localizer"
 BASE_DIR = Path(__file__).resolve().parent
@@ -634,8 +639,7 @@ $notifier.Show($toast)
         out_dir_value = self.output_dir.value.strip()
         out_dir = Path(out_dir_value) if out_dir_value else None
         if not mods_dir or not mods_dir.exists() or not mods_dir.is_dir():
-            display = mods_dir if mods_dir else "(未指定)"
-            self._append_log(f"[ERROR] Mods フォルダが見つかりません: {display}")
+            self._append_log("[ERROR] Mods フォルダが見つかりません。")
             return
         if out_dir is None:
             self._append_log("[ERROR] 出力フォルダを指定してください。")
@@ -643,7 +647,7 @@ $notifier.Show($toast)
         if not out_dir.exists():
             try:
                 out_dir.mkdir(parents=True, exist_ok=True)
-                self._append_log(f"[INFO] 出力フォルダを作成しました: {out_dir}")
+                self._append_log("[INFO] 出力フォルダを作成しました。")
             except Exception as ex:
                 self._append_log(f"[ERROR] 出力フォルダを作成できません: {repr(ex)}")
                 return
@@ -663,13 +667,13 @@ $notifier.Show($toast)
             try:
                 temp_dir_obj = tempfile.TemporaryDirectory(prefix="mc_localizer_")
                 temp_dir_path = Path(temp_dir_obj.name)
-                self._append_log(f"[INFO] 一時作業フォルダ: {temp_dir_path}")
-                self._append_log(f"[RUN] 抽出: {mods_dir}")
+                self._append_log("[INFO] 一時作業フォルダを準備しました。")
+                self._append_log("[RUN] 抽出処理を開始します。")
                 result: ExtractionResult = extract_localizations(
                     mods_dir,
                     temp_dir_path,
                     log=self._append_log,
-                    progress=self._set_progress,
+                    progress=lambda ratio, text: self._set_progress(ratio, f"抽出 {text}"),
                 )
                 targets: list[tuple[str, Path, dict[str, str]]] = []
                 for modid in result.mod_maps.keys():
@@ -690,9 +694,16 @@ $notifier.Show($toast)
                     elif summary.translated_mods == 0:
                         toast_message = "翻訳対象の ja_jp.json は生成されませんでした。"
                     else:
-                        mod_part = f"{summary.translated_mods}/{summary.total_mods} Mod"
+                        if summary.total_mods:
+                            mod_part = (
+                                f"全{summary.total_mods} Mod 中 {summary.translated_mods} Mod 完了"
+                            )
+                        else:
+                            mod_part = f"{summary.translated_mods} Mod 完了"
                         if summary.total_entries:
-                            entry_part = f"、{summary.translated_entries}/{summary.total_entries} 件"
+                            entry_part = (
+                                f"、全{summary.total_entries} 件中 {summary.translated_entries} 件完了"
+                            )
                         else:
                             entry_part = ""
                         toast_message = f"翻訳が完了しました ({mod_part}{entry_part})。"
@@ -709,7 +720,7 @@ $notifier.Show($toast)
                 if temp_dir_obj:
                     temp_dir_obj.cleanup()
                     if temp_dir_path:
-                        self._append_log(f"[INFO] 一時作業フォルダを削除しました: {temp_dir_path}")
+                        self._append_log("[INFO] 一時作業フォルダを削除しました。")
                 self.btn_extract.disabled = False
                 self.btn_extract.update()
                 self._show_completion_toast(toast_message, is_error=toast_is_error)
@@ -747,7 +758,7 @@ $notifier.Show($toast)
         model = model.strip()
         if model not in self.available_models:
             model = self.available_models[0]
-        self._append_log(f"[INFO] リソースパック出力先: {output_dir}")
+        self._append_log("[INFO] リソースパックの出力先を確認しました。")
         self.stop_event.clear()
         self.btn_stop.disabled = False
         self.btn_stop.update()
@@ -778,11 +789,16 @@ $notifier.Show($toast)
                     aborted = True
                     break
                 if not in_path.exists():
-                    self._append_log(f"[WARN] en_us.json が見つかりません: {in_path}")
+                    self._append_log(f"[WARN] {modid}: en_us.json が見つかりません。")
                     continue
                 out_path = in_path.parent / "ja_jp.json"
-                self._append_log(f"[RUN] 翻訳 {idx}/{total_targets}: {modid} -> {out_path}")
-                self._set_progress(0.0, f"翻訳 {idx}/{total_targets} ({modid})")
+                overall_progress = format_block_progress(idx - 1, total_targets, width=12)
+                self._append_log(
+                    "[RUN] 翻訳を開始します。\n"
+                    f"- 全体進捗: {overall_progress}\n"
+                    f"- 対象 Mod: {modid}"
+                )
+                self._set_progress(0.0, f"{modid}: 翻訳開始")
 
                 def _progress_wrapper(ratio: float, text: str, *, _modid: str = modid):
                     label = text.strip()
@@ -794,7 +810,7 @@ $notifier.Show($toast)
                 resume_exists = resume_path.exists()
                 if resume_exists:
                     self._append_log(
-                        f"[INFO] 中断済みの翻訳ファイルを検出しました。未訳を引き継ぎます: {resume_path}"
+                        f"[INFO] {modid}: 中断済みの翻訳ファイルを検出しました。未訳を引き継ぎます。"
                     )
                 if (
                     pack_lang_path
@@ -803,7 +819,7 @@ $notifier.Show($toast)
                 ):
                     skipped_existing += 1
                     self._append_log(
-                        f"[INFO] mods_ja_resource に既存の翻訳が見つかったためスキップします: {pack_lang_path}"
+                        f"[INFO] {modid}: mods_ja_resource に既存の翻訳が見つかったためスキップします。"
                     )
                     self._set_progress(1.0, f"{modid}: 既存訳をスキップ")
                     continue
@@ -845,12 +861,12 @@ $notifier.Show($toast)
                         break
                     if out_path.exists():
                         produced.append((modid, out_path))
-                    self._append_log(f"[OK] ja_jp.json を作成しました: {out_path}")
+                    self._append_log(f"[OK] {modid}: ja_jp.json を作成しました。")
                     pack_dir = self._generate_resource_pack(source_path, temp_dir, output_dir, produced)
                     if pack_dir:
                         pack_dir_path = pack_dir
                         pack_generated_once = True
-                        self._append_log(f"[OK] リソースパックを更新しました ({modid}): {pack_dir}")
+                        self._append_log(f"[OK] リソースパックを更新しました（{modid}）。")
                         _register_pack_contents(pack_dir)
                 except Exception as ex:
                     had_error = True
@@ -867,10 +883,12 @@ $notifier.Show($toast)
                 pack_dir = self._generate_resource_pack(source_path, temp_dir, output_dir, produced)
                 if pack_dir:
                     pack_dir_path = pack_dir
-                    self._append_log(f"[OK] リソースパックを更新しました: {pack_dir}")
+                    self._append_log("[OK] リソースパックを更新しました。")
                     pack_png = pack_dir / "pack.png"
                     if not pack_png.exists():
-                        self._append_log(f"[INFO] pack.png は手動で配置してください: {pack_png}")
+                        self._append_log(
+                            "[INFO] pack.png はリソースパックのルートに手動で配置してください。"
+                        )
                     _register_pack_contents(pack_dir)
             except Exception as ex:
                 had_error = True
@@ -912,7 +930,7 @@ $notifier.Show($toast)
     ) -> Path | None:
         if not produced:
             return None
-        self._append_log(f"[INFO] リソースパック生成: 作業フォルダ {temp_dir} を参照します。")
+        self._append_log("[INFO] リソースパック生成: 作業フォルダの内容を利用します。")
         base_name = self._determine_pack_base_name(source_path)
         if not base_name and produced and produced[0][0]:
             base_name = produced[0][0]


### PR DESCRIPTION
## Summary
- add a reusable block progress formatter for extraction and translation updates and switch UI logs to use it
- simplify logged messages by removing directory paths and presenting multi-value details as lists for easier reading

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68f10413166083279fcbb82c3ce086be