### PR TITLE
Limit history entries and enable streaming

### DIFF
--- a/app/processing.py
+++ b/app/processing.py
@@ -239,8 +239,53 @@ def translate_batch(
         )
         if with_response_format:
             args["response_format"] = response_format_schema
-        try:
+        
+        def _call_streaming() -> Tuple[str, UsageStats]:
+            text_parts: List[str] = []
+            json_parts: List[str] = []
+            usage_stats = UsageStats()
+            final_response = None
+            stream_cm = client.responses.stream(**args)  # type: ignore[arg-type]
+            with stream_cm as stream:
+                for event in stream:
+                    event_type = getattr(event, "type", "")
+                    if event_type == "response.output_text.delta":
+                        delta = getattr(event, "delta", "")
+                        if delta:
+                            text_parts.append(str(delta))
+                    elif event_type == "response.output_json.delta":
+                        delta = getattr(event, "delta", "")
+                        if delta:
+                            json_parts.append(str(delta))
+                    elif event_type == "response.completed":
+                        final_response = getattr(event, "response", None)
+                    elif event_type == "response.failed":
+                        error_obj = getattr(event, "error", None)
+                        raise RuntimeError(f"Response stream failed: {error_obj}")
+                try:
+                    final_response = stream.get_final_response() or final_response
+                except Exception:
+                    final_response = final_response
+            if final_response is not None:
+                usage_stats = _usage_from_response(final_response)
+            out_text = "".join(text_parts) or "".join(json_parts)
+            if not out_text and final_response is not None:
+                out_text = _extract_text(final_response)
+            return out_text, usage_stats
+
+        def _invoke() -> Tuple[str, UsageStats]:
+            if hasattr(client.responses, "stream"):
+                try:
+                    return _call_streaming()
+                except TypeError:
+                    raise
+                except Exception:
+                    pass
             resp = client.responses.create(**args)  # type: ignore[arg-type]
+            return _extract_text(resp), _usage_from_response(resp)
+
+        try:
+            out, usage = _invoke()
         except TypeError:
             if with_response_format:
                 return _call_responses(
@@ -248,8 +293,6 @@ def translate_batch(
                     extra_note + "\n出力は必ず『単一の JSON 配列（順番どおりの日本語訳）』のみで返してください。"
                 )
             raise
-        usage = _usage_from_response(resp)
-        out = _extract_text(resp)
         last_raw = out or ""
         return _parse_list(out), usage
 

--- a/app/ui.py
+++ b/app/ui.py
@@ -50,6 +50,8 @@ class LocalizeApp:
         self.stop_event = threading.Event()
         self._log_lines: list[str] = []
         self._max_log_lines = 500
+        self._log_auto_scroll = True
+        self._max_usage_records = 30
         # 保存キー
         self.K_API = "openai_api_key"
         self.K_MODEL = "openai_model"
@@ -87,6 +89,11 @@ class LocalizeApp:
             min_lines=12,
             max_lines=9999,
             border=ft.InputBorder.OUTLINE,
+        )
+        self.log_auto_scroll_checkbox = ft.Checkbox(
+            label="ログの自動スクロール",
+            value=True,
+            on_change=self._on_log_auto_scroll_change,
         )
         self.progress = ft.ProgressBar(width=420, value=0)
         self.counter = ft.Text("待機中")
@@ -153,7 +160,17 @@ class LocalizeApp:
                     vertical_alignment=ft.CrossAxisAlignment.CENTER,
                 ),
                 progress_panel,
-                self.log,
+                ft.Column(
+                    controls=[
+                        self.log,
+                        ft.Row(
+                            controls=[self.log_auto_scroll_checkbox],
+                            alignment=ft.MainAxisAlignment.END,
+                        ),
+                    ],
+                    spacing=6,
+                    expand=True,
+                ),
             ],
             expand=True,
             spacing=12,
@@ -471,6 +488,8 @@ class LocalizeApp:
                     "cost": cost_f,
                 }
             )
+        if len(history) > self._max_usage_records:
+            history = history[-self._max_usage_records :]
         return history
 
     def _load_total_cost(self) -> float:
@@ -498,7 +517,7 @@ class LocalizeApp:
     def _refresh_usage_history_table(self) -> None:
         rows: list[ft.DataRow] = []
         total_cost = 0.0
-        for record in self.usage_history:
+        for record in self.usage_history[-self._max_usage_records :]:
             cost_value = float(record.get("cost", 0.0))
             total_cost += cost_value
             rows.append(
@@ -546,11 +565,15 @@ class LocalizeApp:
         if len(self._log_lines) > self._max_log_lines:
             self._log_lines = self._log_lines[-self._max_log_lines :]
         self.log.value = "\n".join(self._log_lines)
-        try:
-            self.log.scroll_to(offset=1.0, duration=0)
-        except Exception:
-            pass
+        if self._log_auto_scroll:
+            try:
+                self.log.scroll_to(offset=1.0, duration=0)
+            except Exception:
+                pass
         self.log.update()
+
+    def _on_log_auto_scroll_change(self, e: ft.ControlEvent):
+        self._log_auto_scroll = bool(self.log_auto_scroll_checkbox.value)
 
     def _set_progress(self, ratio: float, text: str = ""):
         self.progress.value = max(0.0, min(1.0, ratio))
@@ -604,9 +627,9 @@ class LocalizeApp:
                     "cost": cost,
                 }
                 self.usage_history.append(record)
-            # keep latest 200 entries to avoid unbounded growth
-            if len(self.usage_history) > 200:
-                self.usage_history = self.usage_history[-200:]
+            # keep only the latest records to avoid unbounded growth
+            if len(self.usage_history) > self._max_usage_records:
+                self.usage_history = self.usage_history[-self._max_usage_records :]
             self._persist_usage_history()
             self._persist_total_cost()
 


### PR DESCRIPTION
## Summary
- add a log auto-scroll toggle and keep the textarea limited to 500 entries
- cap the saved and rendered OpenAI usage history at 30 records
- enable OpenAI Responses streaming with fallback to non-streaming when unavailable

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68f1dfad39088327b405afd93d42b9f0