### PR TITLE
Limit history display and enable streaming responses

### DIFF
--- a/app/processing.py
+++ b/app/processing.py
@@ -239,8 +239,32 @@ def translate_batch(
         )
         if with_response_format:
             args["response_format"] = response_format_schema
+        text_chunks: List[str] = []
+        final_response = None
+        saw_delta_keys: set[tuple[int, int]] = set()
         try:
-            resp = client.responses.create(**args)  # type: ignore[arg-type]
+            with client.responses.stream(**args) as resp_stream:  # type: ignore[arg-type]
+                for event in resp_stream:
+                    event_type = getattr(event, "type", "")
+                    if event_type == "response.output_text.delta":
+                        key = (getattr(event, "output_index", 0), getattr(event, "content_index", 0))
+                        delta = getattr(event, "delta", "")
+                        if delta:
+                            saw_delta_keys.add(key)
+                            text_chunks.append(str(delta))
+                    elif event_type == "response.output_text.done":
+                        key = (getattr(event, "output_index", 0), getattr(event, "content_index", 0))
+                        if key not in saw_delta_keys:
+                            text = getattr(event, "text", "")
+                            if text:
+                                text_chunks.append(str(text))
+                    elif event_type == "response.completed":
+                        final_response = getattr(event, "response", None)
+                if final_response is None:
+                    try:
+                        final_response = resp_stream.get_final_response()
+                    except Exception:
+                        final_response = None
         except TypeError:
             if with_response_format:
                 return _call_responses(
@@ -248,8 +272,12 @@ def translate_batch(
                     extra_note + "\n出力は必ず『単一の JSON 配列（順番どおりの日本語訳）』のみで返してください。"
                 )
             raise
-        usage = _usage_from_response(resp)
-        out = _extract_text(resp)
+        usage = UsageStats()
+        if final_response is not None:
+            usage = _usage_from_response(final_response)
+        out = "".join(text_chunks)
+        if not out and final_response is not None:
+            out = _extract_text(final_response)
         last_raw = out or ""
         return _parse_list(out), usage
 

--- a/app/ui.py
+++ b/app/ui.py
@@ -50,6 +50,7 @@ class LocalizeApp:
         self.stop_event = threading.Event()
         self._log_lines: list[str] = []
         self._max_log_lines = 500
+        self._max_usage_records = 30
         # 保存キー
         self.K_API = "openai_api_key"
         self.K_MODEL = "openai_model"
@@ -60,6 +61,7 @@ class LocalizeApp:
         self.K_LAST_OUTPUT_PATH = "last_output_dir_path"
         self.K_USAGE_HISTORY = "token_usage_history"
         self.K_USAGE_TOTAL_COST = "token_usage_total_cost"
+        self.K_LOG_AUTO_SCROLL = "log_auto_scroll"
         # 既定値
         self.model_pricing = {
             "gpt-5": {"input": 1.25, "cached_input": 0.13, "output": 10.00},
@@ -87,6 +89,13 @@ class LocalizeApp:
             min_lines=12,
             max_lines=9999,
             border=ft.InputBorder.OUTLINE,
+        )
+        auto_scroll_pref = (self._load_value(self.K_LOG_AUTO_SCROLL) or "").lower()
+        auto_scroll_enabled = False if auto_scroll_pref in {"false", "0", "off"} else True
+        self.log_auto_scroll = ft.Checkbox(
+            label="ログを自動スクロール",
+            value=auto_scroll_enabled,
+            on_change=self._on_log_auto_scroll_change,
         )
         self.progress = ft.ProgressBar(width=420, value=0)
         self.counter = ft.Text("待機中")
@@ -153,6 +162,7 @@ class LocalizeApp:
                     vertical_alignment=ft.CrossAxisAlignment.CENTER,
                 ),
                 progress_panel,
+                ft.Row([self.log_auto_scroll], alignment=ft.MainAxisAlignment.END),
                 self.log,
             ],
             expand=True,
@@ -471,6 +481,8 @@ class LocalizeApp:
                     "cost": cost_f,
                 }
             )
+        if len(history) > self._max_usage_records:
+            history = history[-self._max_usage_records :]
         return history
 
     def _load_total_cost(self) -> float:
@@ -546,11 +558,21 @@ class LocalizeApp:
         if len(self._log_lines) > self._max_log_lines:
             self._log_lines = self._log_lines[-self._max_log_lines :]
         self.log.value = "\n".join(self._log_lines)
+        auto_scroll = True
         try:
-            self.log.scroll_to(offset=1.0, duration=0)
+            auto_scroll = bool(self.log_auto_scroll.value)
         except Exception:
-            pass
+            auto_scroll = True
+        if auto_scroll:
+            try:
+                self.log.scroll_to(offset=1.0, duration=0)
+            except Exception:
+                pass
         self.log.update()
+
+    def _on_log_auto_scroll_change(self, e: ft.ControlEvent):
+        value = "true" if self.log_auto_scroll.value else "false"
+        self._save_value(self.K_LOG_AUTO_SCROLL, value)
 
     def _set_progress(self, ratio: float, text: str = ""):
         self.progress.value = max(0.0, min(1.0, ratio))
@@ -604,9 +626,9 @@ class LocalizeApp:
                     "cost": cost,
                 }
                 self.usage_history.append(record)
-            # keep latest 200 entries to avoid unbounded growth
-            if len(self.usage_history) > 200:
-                self.usage_history = self.usage_history[-200:]
+            # keep latest entries within the configured limit to avoid unbounded growth
+            if len(self.usage_history) > self._max_usage_records:
+                self.usage_history = self.usage_history[-self._max_usage_records :]
             self._persist_usage_history()
             self._persist_total_cost()
 


### PR DESCRIPTION
## Summary
- restrict stored token usage history to the latest 30 entries and add a saved toggle for log auto-scroll behaviour
- keep the log capped at 500 lines and expose a checkbox to control automatic scrolling in the extract tab
- enable streaming when calling the OpenAI Responses API while continuing to parse the final output for usage statistics

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68f1dfad39088327b405afd93d42b9f0