### PR TITLE
Enable streaming responses and refine logging UI

### DIFF
--- a/app/processing.py
+++ b/app/processing.py
@@ -239,8 +239,20 @@ def translate_batch(
         )
         if with_response_format:
             args["response_format"] = response_format_schema
+        streamed_parts: List[str] = []
         try:
-            resp = client.responses.create(**args)  # type: ignore[arg-type]
+            with client.responses.stream(**args) as stream:  # type: ignore[arg-type]
+                for event in stream:
+                    event_type = getattr(event, "type", "")
+                    if event_type == "response.output_text.delta":
+                        delta = getattr(event, "delta", "")
+                        if delta:
+                            streamed_parts.append(str(delta))
+                    elif event_type == "response.error":
+                        error = getattr(event, "error", None)
+                        message = getattr(error, "message", None) if error else None
+                        raise RuntimeError(message or "OpenAI streaming error")
+                resp = stream.get_final_response()
         except TypeError:
             if with_response_format:
                 return _call_responses(
@@ -250,6 +262,8 @@ def translate_batch(
             raise
         usage = _usage_from_response(resp)
         out = _extract_text(resp)
+        if not out and streamed_parts:
+            out = "".join(streamed_parts)
         last_raw = out or ""
         return _parse_list(out), usage
 

--- a/app/ui.py
+++ b/app/ui.py
@@ -79,6 +79,11 @@ class LocalizeApp:
         page.window_height = 820
         page.theme_mode = "light"
         # ログ & 進捗
+        self.log_auto_scroll_checkbox = ft.Checkbox(
+            label="ログを自動スクロール",
+            value=True,
+            on_change=self._on_log_auto_scroll_toggle,
+        )
         self.log = ft.TextField(
             label="ログ",
             multiline=True,
@@ -153,6 +158,9 @@ class LocalizeApp:
                     vertical_alignment=ft.CrossAxisAlignment.CENTER,
                 ),
                 progress_panel,
+                ft.Row([
+                    self.log_auto_scroll_checkbox,
+                ], alignment=ft.MainAxisAlignment.END),
                 self.log,
             ],
             expand=True,
@@ -471,6 +479,8 @@ class LocalizeApp:
                     "cost": cost_f,
                 }
             )
+        if len(history) > 30:
+            history = history[-30:]
         return history
 
     def _load_total_cost(self) -> float:
@@ -497,10 +507,9 @@ class LocalizeApp:
 
     def _refresh_usage_history_table(self) -> None:
         rows: list[ft.DataRow] = []
-        total_cost = 0.0
-        for record in self.usage_history:
+        recent_history = self.usage_history[-30:]
+        for record in reversed(recent_history):
             cost_value = float(record.get("cost", 0.0))
-            total_cost += cost_value
             rows.append(
                 ft.DataRow(
                     cells=[
@@ -535,6 +544,14 @@ class LocalizeApp:
     # ------------------------------
     # Log & Progress
     # ------------------------------
+    def _on_log_auto_scroll_toggle(self, e: ft.ControlEvent | None):
+        if not self.log_auto_scroll_checkbox.value:
+            return
+        try:
+            self.log.scroll_to(offset=1.0, duration=0)
+        except Exception:
+            pass
+
     def _append_log(self, msg: str):
         timestamp = datetime.now().strftime("%H:%M:%S")
         raw_lines = msg.splitlines() or [msg]
@@ -546,10 +563,11 @@ class LocalizeApp:
         if len(self._log_lines) > self._max_log_lines:
             self._log_lines = self._log_lines[-self._max_log_lines :]
         self.log.value = "\n".join(self._log_lines)
-        try:
-            self.log.scroll_to(offset=1.0, duration=0)
-        except Exception:
-            pass
+        if self.log_auto_scroll_checkbox.value:
+            try:
+                self.log.scroll_to(offset=1.0, duration=0)
+            except Exception:
+                pass
         self.log.update()
 
     def _set_progress(self, ratio: float, text: str = ""):
@@ -604,9 +622,9 @@ class LocalizeApp:
                     "cost": cost,
                 }
                 self.usage_history.append(record)
-            # keep latest 200 entries to avoid unbounded growth
-            if len(self.usage_history) > 200:
-                self.usage_history = self.usage_history[-200:]
+            # keep latest 30 entries to avoid unbounded growth
+            if len(self.usage_history) > 30:
+                self.usage_history = self.usage_history[-30:]
             self._persist_usage_history()
             self._persist_total_cost()
 


### PR DESCRIPTION
## Summary
- enable streaming when calling the OpenAI Responses API so partial output is supported while preserving fallbacks
- add a toggleable auto-scroll checkbox for the log panel and cap the saved usage history to the most recent 30 entries
- show only the latest 30 API usage records in reverse chronological order to match the new display limit

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68f1dfad39088327b405afd93d42b9f0